### PR TITLE
Proper boot order

### DIFF
--- a/regionServiceClient/cloud-regionsrv-client.spec
+++ b/regionServiceClient/cloud-regionsrv-client.spec
@@ -2,7 +2,7 @@
 # spec file for package cloud-regionsrv-client
 # this code base is under development
 #
-# Copyright (c) 2013 SUSE LLC
+# Copyright (c) 2015 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 #
 
 Name:           cloud-regionsrv-client
-Version:        6.3.6
+Version:        6.3.7
 Release:        0
 License:        LGPL-3.0
 Summary:        Cloud Environment Guest Registration

--- a/regionServiceClient/etc/init.d/guestregister
+++ b/regionServiceClient/etc/init.d/guestregister
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Copyright 2013 SUSE LLC All Rights Reserved.
+# Copyright 2015 SUSE LLC All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 # Provides:          guestregister
 # Required-Start:    $local-fs $network
 # Required-Stop:     $null
+# X-Start-Before:    $cloud-final
 # Default-Start:     2 3 5
 # Default-Stop:
 # Short-Description: Get SMT info and "register" with the server

--- a/regionServiceClient/usr/lib/systemd/system/guestregister.service
+++ b/regionServiceClient/usr/lib/systemd/system/guestregister.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Obtain Cloud SMT info and register with the SMT server
+Requires=network.service
 After=network.service
+Before=cloud-final.service
 
 [Service]
 ExecStart=/usr/sbin/registercloudguest


### PR DESCRIPTION
- regionServiceClient
  - Fix the ordering of the initialization. The registration service needs
    to run prior to cloud-final, if it exists to ensure repositories in on
    demand images are available if a user script is to be executed in the
    cloud-final stage
