### PR TITLE
Make Getopt case-sensitive

### DIFF
--- a/azuremetadata/usr/sbin/azuremetadata
+++ b/azuremetadata/usr/sbin/azuremetadata
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 use XML::LibXML;
-use Getopt::Long;
+use Getopt::Long qw(:config no_ignore_case);
 use JSON;
 
 use AzureMetadata::AzureDisk;
@@ -63,7 +63,7 @@ sub parse_options {
     my %options;
     my $bareOut;
     my $cloudServiceName;
-    my $device;    
+    my $device;
     my $external_ip;
     my $instanceID;
     my $internal_ip;


### PR DESCRIPTION
By default, Getopt isn't case-sensitive, so the `-I` option was overridden by the `-i` option.

Before:

```
# azuremetadata -I
{
   "internal_ip" : "100.67.166.98"
}
# azuremetadata --instance-id
{
   "instanceID" : "suserd-sles11sp4-test06"
}
```

After:

```
# azuremetadata -I
{
   "instanceID" : "suserd-sles11sp4-test06"
}
```

http://stackoverflow.com/questions/5408357/perl-getoptions-case-sensitivity
