### PR TITLE
Instance name

### DIFF
--- a/azuremetadata/Makefile.PL
+++ b/azuremetadata/Makefile.PL
@@ -4,5 +4,5 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     EXE_FILES => ['usr/sbin/azuremetadata'],
     NAME      => 'AzureMetadata',
-    VERSION   => '3.2.1'
+    VERSION   => '4.0.0'
 );

--- a/azuremetadata/azuremetadata.spec
+++ b/azuremetadata/azuremetadata.spec
@@ -20,7 +20,7 @@ Name:           azuremetadata
 # For compatibility, remove provides 11/11/2015
 Provides:       azureMetaData
 Obsoletes:      azureMetaData <= 2.0.1
-Version:        3.2.1
+Version:        4.0.0
 Release:        0
 License:        GPL-3.0+
 Summary:        Collect instance metadata in Azure

--- a/azuremetadata/lib/AzureMetadata/AzureGeneral.pm
+++ b/azuremetadata/lib/AzureMetadata/AzureGeneral.pm
@@ -20,13 +20,13 @@ use warnings;
 use XML::LibXML;
 
 our @ISA    = qw (Exporter);
-our @EXPORT_OK = qw (get_instance_id);
+our @EXPORT_OK = qw (get_instance_name);
 
-sub get_instance_id {
+sub get_instance_name {
     my $xml = shift;
-    my @instances = $xml->getElementsByTagName('Instance');
-    my $id = $instances[0]->getAttribute('id');
-    return $id;
+    my @instance = $xml->getElementsByTagName('Incarnation');
+    my $name = $instance[0]->getAttribute('instance');
+    return $name;
 }
 
 1;

--- a/azuremetadata/usr/sbin/azuremetadata
+++ b/azuremetadata/usr/sbin/azuremetadata
@@ -44,11 +44,11 @@ sub main {
             AzureNetwork::import_config()
         );
         $data{external_ip} = $ip;
-    } elsif ($options{instanceID}) {
-        my $id = AzureGeneral::get_instance_id(
+    } elsif ($options{instance_name}) {
+        my $name = AzureGeneral::get_instance_name(
             AzureNetwork::import_config()
         );
-        $data{instanceID} = $id;
+        $data{instance_name} = $name;
     } elsif ($options{internal_ip}) {
         # Private Internal IP discovery
         my $ip = AzureNetwork::read_internal_ip(
@@ -65,25 +65,25 @@ sub parse_options {
     my $cloudServiceName;
     my $device;
     my $external_ip;
-    my $instanceID;
+    my $instance_name;
     my $internal_ip;
     my $tag;
     my $xmlOut;
     my $result = GetOptions(
-        "bare|b"         => \$bareOut,
-        "cloudservice|c" => \$cloudServiceName,
-        "device|d=s"     => \$device,
-        "external-ip|e"  => \$external_ip,
-        "instance-id|I"  => \$instanceID,
-        "internal-ip|i"  => \$internal_ip,
-        "tag|t"          => \$tag,
-        "xml|x"          => \$xmlOut
+        "bare|b"          => \$bareOut,
+        "cloudservice|c"  => \$cloudServiceName,
+        "device|d=s"      => \$device,
+        "external-ip|e"   => \$external_ip,
+        "instance-name|n" => \$instance_name,
+        "internal-ip|i"   => \$internal_ip,
+        "tag|t"           => \$tag,
+        "xml|x"           => \$xmlOut
     );
     $options{bareOut}          = $bareOut;
     $options{cloudServiceName} = $cloudServiceName;
     $options{device}           = $device;
     $options{external_ip}      = $external_ip;
-    $options{instanceID}       = $instanceID;
+    $options{instance_name}    = $instance_name;
     $options{internal_ip}      = $internal_ip;
     $options{tag}              = $tag;
     $options{xmlOut}           = $xmlOut;
@@ -93,7 +93,7 @@ sub parse_options {
     }
     if ((! $options{cloudServiceName}) &&
         (! $options{external_ip}) &&
-        (! $options{instanceID})  &&
+        (! $options{instance_name})  &&
         (! $options{internal_ip}) &&
         (! $options{tag})
     ) {
@@ -121,8 +121,8 @@ sub usage {
     print "    --external-ip | -e\n";
     print "      print public external IPv4 address\n";
     print "\n";
-    print "    --instance-id | -I\n";
-    print "      print the instance identifier\n";
+    print "    --instance-name | -n\n";
+    print "      print the instance's unique name\n";
     print "\n";
     print "    --internal-ip | -i\n";
     print "      print private internal IPv4 address\n";


### PR DESCRIPTION
Prior versions referred to the instance's name via the `--instance-id` parameter, based on a poorly named attribute in waagent's XML.
