### PR TITLE
Fixed behaviour and added new instance information

### DIFF
--- a/azuremetadata/lib/AzureMetadata/AzureGeneral.pm
+++ b/azuremetadata/lib/AzureMetadata/AzureGeneral.pm
@@ -20,13 +20,78 @@ use warnings;
 use XML::LibXML;
 
 our @ISA    = qw (Exporter);
-our @EXPORT_OK = qw (get_instance_name);
+our @EXPORT_OK = qw (
+    get_instance_name
+    get_instance_incarnation_tag
+    get_instance_id
+);
 
 sub get_instance_name {
     my $xml = shift;
-    my @instance = $xml->getElementsByTagName('Incarnation');
-    my $name = $instance[0]->getAttribute('instance');
+    my @instances = $xml->getElementsByTagName('Instance');
+    my $name = $instances[0]->getAttribute('id');
     return $name;
+}
+
+sub get_instance_incarnation_tag {
+    my $xml = shift;
+    my @instance = $xml->getElementsByTagName('Incarnation');
+    my $tag = $instance[0]->getAttribute('instance');
+    return $tag;
+}
+
+sub get_instance_id {
+    my $smbios = qx(dmidecode | grep UUID | cut -c8-);
+    my $id = _fixup_guid_endianness($smbios);
+    return $id;
+}
+
+sub _fixup_guid_endianness {
+    # /.../
+    # Convert a string in the expected format, into 16 bytes,
+    # emulating .Net's Guid constructor
+    # ----
+    my $id   = shift;
+    chomp($id);
+    my $hx   = '[0-9a-f]';
+    if ($id !~ /^($hx{8})-($hx{4})-($hx{4})-($hx{4})-($hx{12})$/i) {
+        return;
+    }
+    my @parts = split (/-/,$id);
+    #==========================================
+    # pack into signed long 4 byte
+    #------------------------------------------
+    my $p1 = $parts[0];
+    $p1 = pack   'H*', $p1;
+    $p1 = unpack 'l>', $p1;
+    $p1 = pack   'l' , $p1;
+    $p1 = unpack 'H*', $p1;
+    #==========================================
+    # pack into unsigned short 2 byte
+    #------------------------------------------
+    my $p2 = $parts[1];
+    $p2 = pack   'H*', $p2;
+    $p2 = unpack 'S>', $p2;
+    $p2 = pack   'S' , $p2;
+    $p2 = unpack 'H*', $p2;
+    #==========================================
+    # pack into unsigned short 2 byte
+    #------------------------------------------
+    my $p3 = $parts[2];
+    $p3 = pack   'H*', $p3;
+    $p3 = unpack 'S>', $p3;
+    $p3 = pack   'S' , $p3;
+    $p3 = unpack 'H*', $p3;
+    #==========================================
+    # pack into hex string (high nybble first)
+    #------------------------------------------
+    my $p4 = $parts[3];
+    my $p5 = $parts[4];
+    #==========================================
+    # concat result and return
+    #------------------------------------------
+    my $guid = "$p1-$p2-$p3-$p4-$p5";
+    return $guid;
 }
 
 1;

--- a/azuremetadata/lib/AzureMetadata/AzureGeneral.pm
+++ b/azuremetadata/lib/AzureMetadata/AzureGeneral.pm
@@ -33,11 +33,11 @@ sub get_instance_name {
     return $name;
 }
 
-sub get_instance_incarnation_tag {
+sub get_incarnation_instance_id {
     my $xml = shift;
-    my @instance = $xml->getElementsByTagName('Incarnation');
-    my $tag = $instance[0]->getAttribute('instance');
-    return $tag;
+    my @incarnation = $xml->getElementsByTagName('Incarnation');
+    my $id = $incarnation[0]->getAttribute('instance');
+    return $id;
 }
 
 sub get_instance_id {

--- a/azuremetadata/usr/sbin/azuremetadata
+++ b/azuremetadata/usr/sbin/azuremetadata
@@ -54,11 +54,11 @@ sub main {
     } elsif ($options{instance_id}) {
         my $id = AzureGeneral::get_instance_id();
         $data{instance_id} = $id;
-    } elsif ($options{instance_tag}) {
-        my $tag = AzureGeneral::get_instance_incarnation_tag(
+    } elsif ($options{incarnation_id}) {
+        my $id = AzureGeneral::get_incarnation_instance_id(
             AzureNetwork::import_config()
         );
-        $data{instance_tag} = $tag;
+        $data{incarnation_instance_id} = $id;
     } elsif ($options{internal_ip}) {
         # Private Internal IP discovery
         my $ip = AzureNetwork::read_internal_ip(
@@ -76,7 +76,7 @@ sub parse_options {
     my $device;
     my $external_ip;
     my $instance_name;
-    my $instance_tag;
+    my $incarnation_id;
     my $instance_id;
     my $internal_ip;
     my $tag;
@@ -87,8 +87,8 @@ sub parse_options {
         "device|d=s"      => \$device,
         "external-ip|e"   => \$external_ip,
         "instance-name|n" => \$instance_name,
-        "instance-tag|g"  => \$instance_tag,
-        "instance-id|d"   => \$instance_id,
+        "incarnation-id|I"=> \$incarnation_id,
+        "instance-id|D"   => \$instance_id,
         "internal-ip|i"   => \$internal_ip,
         "tag|t"           => \$tag,
         "xml|x"           => \$xmlOut
@@ -100,7 +100,7 @@ sub parse_options {
     $options{instance_name}    = $instance_name;
     $options{internal_ip}      = $internal_ip;
     $options{instance_id}      = $instance_id;
-    $options{instance_tag}     = $instance_tag;
+    $options{incarnation_id}   = $incarnation_id;
     $options{tag}              = $tag;
     $options{xmlOut}           = $xmlOut;
     if ( $result != 1 ) {
@@ -111,7 +111,7 @@ sub parse_options {
     if ((! $options{cloudServiceName}) &&
         (! $options{external_ip}) &&
         (! $options{instance_name})  &&
-        (! $options{instance_tag}) &&
+        (! $options{incarnation_id}) &&
         (! $options{instance_id}) &&
         (! $options{internal_ip}) &&
         (! $options{tag})
@@ -144,11 +144,11 @@ sub usage {
     print "    --instance-name | -n\n";
     print "      print the instance's name\n";
     print "\n";
-    print "    --instance-tag | -g\n";
-    print "      print the instance's unique tag name\n";
+    print "    --incarnation-id | -I\n";
+    print "      print the instance's unique incarnation tag\n";
     print "\n";
-    print "    --instance-id | -d\n";
-    print "      print the instance's unique id\n";
+    print "    --instance-id | -D\n";
+    print "      print the instance's unique SMBIOS UUID\n";
     print "\n";
     print "    --internal-ip | -i\n";
     print "      print private internal IPv4 address\n";

--- a/azuremetadata/usr/sbin/azuremetadata
+++ b/azuremetadata/usr/sbin/azuremetadata
@@ -14,6 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# use lib '../../lib';
 
 use strict;
 use warnings;
@@ -49,6 +51,14 @@ sub main {
             AzureNetwork::import_config()
         );
         $data{instance_name} = $name;
+    } elsif ($options{instance_id}) {
+        my $id = AzureGeneral::get_instance_id();
+        $data{instance_id} = $id;
+    } elsif ($options{instance_tag}) {
+        my $tag = AzureGeneral::get_instance_incarnation_tag(
+            AzureNetwork::import_config()
+        );
+        $data{instance_tag} = $tag;
     } elsif ($options{internal_ip}) {
         # Private Internal IP discovery
         my $ip = AzureNetwork::read_internal_ip(
@@ -66,6 +76,8 @@ sub parse_options {
     my $device;
     my $external_ip;
     my $instance_name;
+    my $instance_tag;
+    my $instance_id;
     my $internal_ip;
     my $tag;
     my $xmlOut;
@@ -75,6 +87,8 @@ sub parse_options {
         "device|d=s"      => \$device,
         "external-ip|e"   => \$external_ip,
         "instance-name|n" => \$instance_name,
+        "instance-tag|g"  => \$instance_tag,
+        "instance-id|d"   => \$instance_id,
         "internal-ip|i"   => \$internal_ip,
         "tag|t"           => \$tag,
         "xml|x"           => \$xmlOut
@@ -85,6 +99,8 @@ sub parse_options {
     $options{external_ip}      = $external_ip;
     $options{instance_name}    = $instance_name;
     $options{internal_ip}      = $internal_ip;
+    $options{instance_id}      = $instance_id;
+    $options{instance_tag}     = $instance_tag;
     $options{tag}              = $tag;
     $options{xmlOut}           = $xmlOut;
     if ( $result != 1 ) {
@@ -95,11 +111,13 @@ sub parse_options {
     if ((! $options{cloudServiceName}) &&
         (! $options{external_ip}) &&
         (! $options{instance_name})  &&
+        (! $options{instance_tag}) &&
+        (! $options{instance_id}) &&
         (! $options{internal_ip}) &&
         (! $options{tag})
     ) {
         usage();
-        print STDERR "Please provide a query option.";
+        print STDERR "Please provide a query option.\n";
         exit 1;
     }
     if (! $options{device}) {
@@ -124,7 +142,13 @@ sub usage {
     print "      print public external IPv4 address\n";
     print "\n";
     print "    --instance-name | -n\n";
-    print "      print the instance's unique name\n";
+    print "      print the instance's name\n";
+    print "\n";
+    print "    --instance-tag | -g\n";
+    print "      print the instance's unique tag name\n";
+    print "\n";
+    print "    --instance-id | -d\n";
+    print "      print the instance's unique id\n";
     print "\n";
     print "    --internal-ip | -i\n";
     print "      print private internal IPv4 address\n";


### PR DESCRIPTION
- The --instance-name option should return the name and not the incarnation tag.
- A new option --instance-tag returns the incarnation tag
- A new option --instance-id returns the instance id as representation of the smbios UUID
