### PR TITLE
Manpage improvements

### DIFF
--- a/susePublicCloudInfoClient/lib/susepubliccloudinfoclient.egg-info/PKG-INFO
+++ b/susePublicCloudInfoClient/lib/susepubliccloudinfoclient.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: susepubliccloudinfoclient
-Version: 0.0.1
+Version: 0.1.2
 Summary: Command-line tool to access SUSE Public Cloud Information Service
 Home-page: https://github.com/SUSE/Enceladus
 Author: SUSE Public Cloud Team

--- a/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/version.py
+++ b/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/version.py
@@ -18,4 +18,4 @@
 # along with susePublicCloudInfoClient. If not, see
 # <http://www.gnu.org/licenses/>.
 #
-VERSION = '0.1.1'
+VERSION = '0.1.2'

--- a/susePublicCloudInfoClient/man/man1/pint.1
+++ b/susePublicCloudInfoClient/man/man1/pint.1
@@ -5,7 +5,7 @@
 .SH NAME
 pint \- Public-cloud INformation Tracker
 .SH SYNOPSIS
-.B pint amazon|google|hp|microsoft images|servers [option]
+.B pint amazon|google|hp|microsoft images|servers [options]
 .SH DESCRIPTION
 .B pint
 A client for the SUSE Public Cloud Information service at
@@ -29,8 +29,8 @@ in Amazon Web Services EC2 in JSON format.
 .IP https://susepubliccloudinfo.suse.com/v1/google/images/active.json
 Provides information about all the active images in Google Compute images
 in JSON format.
-.IP https://susepubliccloudinfo.suse.com/v1/microsoft/West US/images/active.xml
-Provides information about all active images in Microsoft Azure in the US-West
+.IP https://susepubliccloudinfo.suse.com/v1/microsoft/West%20US/images/active.xml
+Provides information about all active images in Microsoft Azure in the 'West US'
 region.
 .P
 The
@@ -93,8 +93,8 @@ are considered deprecated. The SUSE deprecation period is 6 months.
 .IP "--filter"
 Filter the information based on the given value(s). If the information is
 to be filtered on more than one entry type provide a comma separated
-list. The output id the union of the filters. The filter option
-specifies one or more of the valid data entries for the chosen
+list. The output is a subset of results that match all the filters. The filter 
+option specifies one or more of the valid data entries for the chosen
 .I <data-selector>
 and is a valid option for the
 .I images
@@ -156,7 +156,7 @@ DNS lookup. The name for all region servers are the same,
 across all cloud frameworks.
 .RS
 .P
-For example:
+Example:
 .IP --filter="publishedon>20150101,name~11-sp3"
 Filters images to a subset with a name containing "11-sp3" and published after 
 Jan 1, 2015.
@@ -167,7 +167,7 @@ Print a help message.
 Set the output format to JSON format. The option is mutually exclusive with
 the
 .I --xml
-option. If neither option is specified plain text information is provided.
+option. XML is the default output format if neither option is provided.
 .IP "--region"
 Specify the region for which the information is supposed to be retrieved.
 If no information is specified information for all regions in the given
@@ -200,5 +200,10 @@ Engine in JSON format.
 
 Will provide information about the active images in Amazon Web Services EC2
 in the us-west-2 region (Oregon).
+
+.B pint microsoft images --active --filter="name~priority"
+
+Will provide information about the active 'priority' images in Microsoft Azure.
+
 .SH AUTHORS
 Robert Schweikert (rjschwei@suse.com), James Mason (jmason@suse.com)

--- a/susePublicCloudInfoClient/python-susepubcloudinfo.spec
+++ b/susePublicCloudInfoClient/python-susepubcloudinfo.spec
@@ -18,7 +18,7 @@
 
 %define upstream_name susepubcloudinfo
 Name:           python-susepubcloudinfo
-Version:        0.1.1
+Version:        0.1.2
 Release:        0
 Summary:        Query SUSE Public Cloud Info Service
 License:        GPL-3.0+


### PR DESCRIPTION
- Some typos
- The example API URL for Azure lacked the URL-encoded space in the region name
- Removed reference to the plain output format; recognized XML as the default output
- Reworded some clumsy language around filters
- Added an example in the footer with a filter
