### PR TITLE
Alter XML output to be compatible with both Python 2.6 & 2.7

### DIFF
--- a/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/infoserverrequests.py
+++ b/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/infoserverrequests.py
@@ -192,7 +192,7 @@ def __reformat(items, info_type, result_format):
         root = ET.Element(info_type)
         for item in items:
             ET.SubElement(root, __inflect(info_type), item)
-        return ET.tostring(root, 'UTF-8', 'xml')
+        return ET.tostring(root, 'UTF-8')
 
 
 def __select_server_format(result_format, apply_filters=False):

--- a/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/version.py
+++ b/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/version.py
@@ -18,4 +18,4 @@
 # along with susePublicCloudInfoClient. If not, see
 # <http://www.gnu.org/licenses/>.
 #
-VERSION = '0.1.3'
+VERSION = '0.1.4'

--- a/susePublicCloudInfoClient/python-susepubliccloudinfo.spec
+++ b/susePublicCloudInfoClient/python-susepubliccloudinfo.spec
@@ -18,7 +18,7 @@
 
 %define upstream_name susepubliccloudinfo
 Name:           python-susepubliccloudinfo
-Version:        0.1.3
+Version:        0.1.4
 Release:        0
 Summary:        Query SUSE Public Cloud Info Service
 License:        GPL-3.0+


### PR DESCRIPTION
Python 2.7 introduced a third param to
xml.etree.ElementTree.tostring(element, encoding="us-ascii", method="xml")
, but it defaults to the desired value: xml.

Python 2.6 (Included in SLE 11) did not have this attribute, so the method
failed there.

Relying on the default value for Python 2.7 (SLE 12, openSUSE,
Tumbleweed) satisfies both options.
