### PR TITLE
Makefile: clean up python bytecode for release tar

### DIFF
--- a/susePublicCloudInfoClient/Makefile
+++ b/susePublicCloudInfoClient/Makefile
@@ -5,6 +5,8 @@ NAME=susepubliccloudinfo
 dirs = bin lib man
 files = Makefile README.md LICENSE setup.py
 
+.PHONY: clean tar install pep8 test coverage list_tests
+
 nv = $(shell rpm -q --specfile --qf '%{NAME}-%{VERSION}|' *.spec | cut -d'|' -f1)
 verSpec = $(shell rpm -q --specfile --qf '%{VERSION}|' *.spec | cut -d'|' -f1)
 verSrc = $(shell cat lib/susepubliccloudinfoclient/version.py | \
@@ -14,7 +16,11 @@ ifneq "$(verSpec)" "$(verSrc)"
 $(error "Version mismatch, will not take any action")
 endif
 
-tar:
+clean:
+	find -name __pycache__ -exec rm -r {} +
+	find -name \*.pyc -exec rm {} +
+
+tar:  clean
 	mkdir -p "$(NAME)-$(verSrc)"/man/man1
 	cp -r $(dirs) $(files) "$(NAME)-$(verSrc)"
 	tar -cjf "$(NAME)-$(verSrc).tar.bz2" "$(NAME)-$(verSrc)"
@@ -29,7 +35,6 @@ install:
 pep8:
 	tools/run-pep8
 
-.PHONY: test
 test:
 	nosetests --with-coverage --cover-erase --cover-package=lib.susepubliccloudinfoclient --cover-xml
 	tools/coverage-check


### PR DESCRIPTION
Prevents accidentally including python bytecode in the release tarball.
