### PR TITLE
Exit process when ssh key file not found.

### DIFF
--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -379,10 +379,12 @@ try:
         if not ssh_private_key_file:
             print >> sys.stderr, 'Could not determine the private ssh key file'
             sys.exit(1)
+
         if not os.path.exists(ssh_private_key_file):
             print >> sys.stderr, ('SSH private key file "%s" does not exist'
                                   % ssh_private_key_file)
-    
+            sys.exit(1)
+
         ssh_user = args.sshUser
         if not ssh_user:
             ssh_user = utils.get_from_config(args.accountName,


### PR DESCRIPTION
If ssh key file is not found at the given location,
ssh_private_key_file, exit the upload process after
displaying an error message.

Fixed #99 
