### PR TITLE
- ec2utils --ec2uploadimg

### DIFF
--- a/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
+++ b/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
@@ -707,7 +707,7 @@ class EC2ImageUploader(EC2Utils):
         register_args = {
             'Architecture' : self.image_arch,
             'BlockDeviceMappings' : block_device_map,
-            'Description' : self.image_description,
+            'Description' : self.image_description.strip(),
             'EnaSupport' : self.ena_support,
             'Name' : self.image_name,
             'RootDeviceName' : root_device_name,


### PR DESCRIPTION
  + AWS interface doe not accept leading or trailing speces in the
    description, strip those rather then making the user re enter a
    corrected command line