### PR TITLE
- regionServiceClient

### DIFF
--- a/regionServiceClient/lib/cloudregister/registerutils.py
+++ b/regionServiceClient/lib/cloudregister/registerutils.py
@@ -31,6 +31,7 @@ HOSTSFILE_PATH = '/etc/hosts'
 REGISTRATION_DATA_DIR = '/var/lib/cloudregister/'
 REGISTERED_SMT_SERVER_DATA_FILE_NAME = 'currentSMTInfo.obj'
 
+
 # ----------------------------------------------------------------------------
 def add_hosts_entry(smt_server):
     """Add an entry to the /etc/hosts file for the given SMT server"""
@@ -47,6 +48,7 @@ def add_hosts_entry(smt_server):
     hosts.write(entry)
     hosts.close()
     logging.info('Modified /etc/hosts, added: %s' % entry)
+
 
 # ----------------------------------------------------------------------------
 def check_registration(smt_server_name):
@@ -75,6 +77,16 @@ def clean_hosts_file(domain_name):
     with open(HOSTSFILE_PATH, 'w') as hosts_file:
         for entry in new_hosts_content:
             hosts_file.write(entry)
+
+
+# ----------------------------------------------------------------------------
+def enable_repository(repo_name):
+    """Enable the given repository"""
+
+    cmd = ['zypper', 'mr', '-e', repo_name]
+    res = exec_subprocess(cmd)
+    if not res:
+        logging.error('Unable to enable repository %s' % repo_name)
 
 
 # ----------------------------------------------------------------------------

--- a/regionServiceClient/usr/sbin/registercloudguest
+++ b/regionServiceClient/usr/sbin/registercloudguest
@@ -425,9 +425,10 @@ if (os.path.exists(register11) and os.access(register11, os.X_OK)):
     if not reposExist:
         cmd = "suse_register --restore-repos"
         res = os.system(cmd)
+        if res:
+            logging.info('Repositories were not restored')
 
-    if res:
-        logging.info('Repositories were not restored')
+    utils.enable_repository('SLE11-Public-Cloud-Module')
 
 elif (os.path.exists(register12) and os.access(register12, os.X_OK)):
     # get product list


### PR DESCRIPTION
  + On SLES 11 the delivered Public Cloud Module repository is disabled
    by default. This is a setting controlled by SCC and passed on through
    SMT to the client. We have no option of modifying the setting on our
    SMT servers and therefore need to enable the repository on the client
    after registration is complete.