### PR TITLE
- regionServiceClient

### DIFF
--- a/regionServiceClient/etc/regionserverclnt.cfg
+++ b/regionServiceClient/etc/regionserverclnt.cfg
@@ -2,7 +2,7 @@
 api = regionInfo
 certLocation = /var/lib/regionService/certs
 regionsrv = COMMA_SEP_LIST_OF_CLOUD_SPECIFIC_REGION_SERVER
-use_metadata_server = OPTIONAL_URL_FOR_METADATA_SERVER_SMT_INFO
+metadata_server = OPTIONAL_URL_FOR_METADATA_SERVER_SMT_INFO
 
 [instance]
 dataProvider = none

--- a/regionServiceClient/lib/cloudregister/registerutils.py
+++ b/regionServiceClient/lib/cloudregister/registerutils.py
@@ -154,6 +154,7 @@ def exec_subprocess(cmd, return_output=False):
 # ----------------------------------------------------------------------------
 def fetch_smt_data(cfg, proxies):
     """Retrieve the data for the region SMT servers from a remote host"""
+    response = None
     if cfg.has_option('server', 'metadata_server'):
         metadata_url = cfg.get('server', 'metadata_server')
         msg = 'Using metadata server "%s" to obtain SMT information'


### PR DESCRIPTION
  + Define response variable, in case of misconfiguration it may not
    be set resulting in a traceback
  + Fix example configuration, mismatch in option name between config
    file and the option the code was looking for