### PR TITLE
- ec2utils -- ec2uploadimage

### DIFF
--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with ec2uploadimg. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import print_function
 
 import configparser
 import argparse

--- a/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
+++ b/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with ec2uploadimg. If not, see <http://www.gnu.org/licenses/>.
-from __future__ import print_function
 
 import boto3
 import os


### PR DESCRIPTION
  + Remove Python 2 compatibility. As stated in teh setup.py file
    the ec2utils are intended to be a Python 3 set of tools. Python 2 is not
    and will not be supported.