### PR TITLE
- regionServiceClient

### DIFF
--- a/regionServiceClient/cloud-regionsrv-client.spec
+++ b/regionServiceClient/cloud-regionsrv-client.spec
@@ -16,7 +16,7 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-%define base_version 8.0.1
+%define base_version 8.0.2
 Name:           cloud-regionsrv-client
 Version:        %{base_version}
 Release:        0

--- a/regionServiceClient/usr/lib/systemd/system/guestregister.service
+++ b/regionServiceClient/usr/lib/systemd/system/guestregister.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Obtain Cloud SMT info and register with the SMT server
-Requires=network.service
-After=network.service
+After=network-online.target
 Before=cloud-final.service waagent.service google-startup-scripts.service
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/sbin/registercloudguest


### PR DESCRIPTION
  + Start only after the network is online. Although for registration to
    an update server within a cloud framework the network does not have to
    be fully operational, if the user has custom repos that point to a
    location that requires DNS we have to have the network fully configured.