### PR TITLE
Implement targetFilename parameter

### DIFF
--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -187,6 +187,11 @@ argparse.add_argument(
     type=int
 )
 argparse.add_argument(
+    '--target-filename',
+    dest="targetFilename",
+    help='The target filename'
+)
+argparse.add_argument(
     '-t', '--type',
     dest='instType',
     help='Instance type to use to upload image (Optional)',
@@ -541,7 +546,7 @@ try:
             ami = uploader.create_image_use_root_swap(args.source)
             print('Created image: ', ami)
         else:
-            ami = uploader.create_image(args.source)
+            ami = uploader.create_image(args.source, args.targetFilename)
             print('Created image: ', ami)
 except EC2UploadImgException as e:
     print(format(e), file=sys.stderr)

--- a/ec2utils/ec2uploadimg/man/man1/ec2uploadimg.1
+++ b/ec2utils/ec2uploadimg/man/man1/ec2uploadimg.1
@@ -140,6 +140,9 @@ driver has to be included in the image.
 .IP "--ssh-timeout SSH_TIME_OUT"
 Specifies the amount of time to wait in seconds to establish an SSH connection
 with the helper instance.
+.IP "--targetFilename filename"
+Specifies the target filename of the source, e.g. when you want to rename the
+source while uploading.
 .IP "-t --type AWS_UPLOAD_INST_TYPE"
 Specifies the instance type to launch for the instance being used to upload
 the image. This value overrides the value given with the


### PR DESCRIPTION
to make it possible renaming the source while uploading to the target.

The purpose of the feature is that for our uploader job the OBS backend renames the files to ``ID.file``, e.g. ``42.file``. ec2uploadimg can not handle these file extensions (and ec2uploadimg needs to know how handle the uploaded file, e.g. extracting). Therefore I propose to make it possible to hand over a filename and not only the source to rename the source while uploading to the target.

@rjschwei does this make sense?