### PR TITLE
Fix find images by name functions to handle pending images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+
+# Unit test
+.cache

--- a/ec2utils/ec2utilsbase/lib/ec2utils/ec2utilsutils.py
+++ b/ec2utils/ec2utilsbase/lib/ec2utils/ec2utilsutils.py
@@ -75,7 +75,7 @@ def find_images_by_name(images, image_name):
     """Return a list of images that match the given name."""
     matching_images = []
     for image in images:
-        if not image['Name']:
+        if not image.get('Name'):
             print(_no_name_warning(image))
             continue
         if image_name == image['Name']:
@@ -90,7 +90,7 @@ def find_images_by_name_fragment(images, image_name_fragment):
        of the image name."""
     matching_images = []
     for image in images:
-        if not image['Name']:
+        if not image.get('Name'):
             print(_no_name_warning(image))
             continue
         if image['Name'].find(image_name_fragment) != -1:
@@ -106,7 +106,7 @@ def find_images_by_name_regex_match(images, image_name_regex):
     matching_images = []
     image_name_exp = re.compile(image_name_regex)
     for image in images:
-        if not image['Name']:
+        if not image.get('Name'):
             print(_no_name_warning(image))
             continue
         if image_name_exp.match(image['Name']):
@@ -208,5 +208,5 @@ def _basic_account_check(config, command_args):
 def _no_name_warning(image):
     """Print a warning for images that have no name"""
     msg = 'WARNING: Found image with no name, ignoring for search results. '
-    msg += 'Image ID: %s' % image.id
+    msg += 'Image ID: %s' % image['ImageId']
     print(msg)

--- a/ec2utils/ec2utilsbase/lib/ec2utils/ec2utilsutils.py
+++ b/ec2utils/ec2utilsbase/lib/ec2utils/ec2utilsutils.py
@@ -17,7 +17,6 @@
 
 import boto3
 import configparser
-import os
 import re
 import sys
 

--- a/ec2utils/ec2utilsbase/tests/test_ec2utilsutils.py
+++ b/ec2utils/ec2utilsbase/tests/test_ec2utilsutils.py
@@ -122,6 +122,20 @@ def test_find_images_by_name_find_some():
     assert 'testimage-1' == found_images[1]['Name']
 
 
+def test_find_images_by_name_pending_image():
+    """
+    Test find_images_by_name does not raise if an image is pending.
+
+    If Status is pending image will not have a name key.
+    """
+    images = _get_test_images()
+    image = {}
+    image['Status'] = 'pending'
+    image['ImageId'] = 'testimage-3'
+    images.append(image)
+    utils.find_images_by_name(images, 'testimage-1')
+
+
 def test_find_images_by_name_find_none():
     """Test find_images_by_name finds nothing and does not error"""
     images = _get_test_images()


### PR DESCRIPTION
If image is pending there will be no Name key. Use get method to return default None if key does not exist.

- Update unit tests, fix test file name for pytest autodiscovery
- Add regression test to cover pending image with no name
- Remove unused os import
- Fix _no_name_warning function to accept dict not object