### PR TITLE
Use validate method to validate share-with arg.

### DIFF
--- a/ec2utils/ec2publishimg/ec2publishimg
+++ b/ec2utils/ec2publishimg/ec2publishimg
@@ -17,10 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with ec2publishimg. If not, see <http://www.gnu.org/licenses/>.
 
-import boto3
 import argparse
 import os
-import re
 import sys
 
 import ec2utils.ec2utilsutils as utils
@@ -208,11 +206,11 @@ if not secret_key:
 regions = utils.get_regions(args, access_key, secret_key)
 
 visibility = args.share.lower()
-aws_account_no = re.compile('(\d{12},?)*')
 if (
-        visibility != 'all' and
-        visibility != 'none' and not
-        aws_account_no.match(visibility)):
+    visibility != 'all' and
+    visibility != 'none' and not
+    utils.validate_account_numbers(visibility)
+):
     msg = 'Expecting "all", "none", or comma separated list of 12 digit AWS '
     msg += 'account numbers as value of --share'
     print(msg, file=sys.stderr)

--- a/ec2utils/ec2utilsbase/lib/ec2utils/ec2utilsutils.py
+++ b/ec2utils/ec2utilsbase/lib/ec2utils/ec2utilsutils.py
@@ -21,6 +21,8 @@ import os
 import re
 import sys
 
+from itertools import repeat
+
 from ec2utils.ec2UtilsExceptions import (
     EC2AccountException,
     EC2ConfigFileParseException
@@ -210,3 +212,11 @@ def _no_name_warning(image):
     msg = 'WARNING: Found image with no name, ignoring for search results. '
     msg += 'Image ID: %s' % image.id
     print(msg)
+
+
+# ----------------------------------------------------------------------------
+def validate_account_numbers(share_with):
+    accounts = list(filter(None, share_with.split(',')))
+    if accounts:
+        return all(map(re.match, repeat('^\d{12}$'), accounts))
+    return False


### PR DESCRIPTION
This is minor given it's an error case but any value thrown at the current regex yields an instance of _sre.SRE_Match. Thus it always evaluates to True.

Tried making a suitable regex but after fighting with it I chose to just use Python split with a separate validate function.

Given the use of split maybe this should be re-worked more to store the validated and split list so it doesn't have to be parsed twice. Also, the validate function could be added to the generic utils file instead of creating a new one for publish.