### PR TITLE
Implement --create-temporary-security-group option

### DIFF
--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -61,6 +61,13 @@ argparse.add_argument(
     metavar='AWS_AKI_ID'
 )
 argparse.add_argument(
+    '--create-temporary-security-group',
+    action='store_true',
+    default=False,
+    dest='createTemporarySecurityGroup',
+    help='Creates a temporary security group with SSH port 22 open'
+)
+argparse.add_argument(
     '-d', '--description',
     dest='descript',
     help='Image description, will also be used for the snapshot',
@@ -509,6 +516,7 @@ try:
                           backing_store=args.backingStore,
                           billing_codes=args.billingCodes,
                           bootkernel=bootkernel,
+                          create_temporary_security_group=args.createTemporarySecurityGroup,
                           ena_support=args.ena,
                           image_arch=args.arch,
                           image_description=args.descript,

--- a/ec2utils/ec2uploadimg/man/man1/ec2uploadimg.1
+++ b/ec2utils/ec2uploadimg/man/man1/ec2uploadimg.1
@@ -66,6 +66,9 @@ image. This option overrides the
 or
 .I g2_aki_x86_64
 value in the configuration file.
+.IP "--create-temporary-security-group"
+Creates a temporary security group with open SSH port 22
+which will get attached to the EC2 helper instance.
 .IP "-d --description IMAGE_DESCRIPTION"
 Specifies a description for the image. The description will also be used for
 the snapshot.


### PR DESCRIPTION
to create a temporary security group with SSH port 22 open.
This is necessary when you do not want to specify a security group but want to
ensure that the helper instance has port 22 open to make it possible to login in via SSH.

This feature is also needed for the OBS cloud uploader. This will make it more convenient for users to upload ec2 images as they don't need to open the port 22 on the default security group or need to create and specify a dedicated security group.