### PR TITLE
Extract EC2Setup class

### DIFF
--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -26,6 +26,7 @@ import sys
 import ec2utils.ec2utilsutils as utils
 import ec2utils.ec2uploadimg as ec2upimg
 from ec2utils.ec2UtilsExceptions import *
+from ec2utils.ec2setup import EC2Setup
 
 # Set up command line argument parsing
 argparse = argparse.ArgumentParser(description='Upload image to Amazon EC2')
@@ -359,6 +360,7 @@ if (
     print('--instance-id, or --boot-kernel', file=sys.stderr)
     sys.exit(1)
 
+setup = EC2Setup(access_key, region, secret_key, args.sessionToken, args.verbose)
 try:
     ami_id = args.amiID
     running_id = args.runningID
@@ -437,41 +439,43 @@ try:
                                               '--type')
 
         key_pair_name = args.sshName
+        ssh_private_key_file = args.privateKey
+        if not key_name and not ssh_private_key_file and not args.accountName:
+            key_pair_name, ssh_private_key_file = setup.create_upload_key_pair()
         if not key_pair_name:
             key_pair_name = utils.get_from_config(args.accountName,
                                                   config,
                                                   region,
                                                   'ssh_key_name',
                                                   '--ssh-key-pair')
+        if not key_pair_name:
+            print('Could not determine key pair name', file=sys.stderr)
+            sys.exit(1)
 
-        ssh_private_key_file = args.privateKey
         if not ssh_private_key_file:
             ssh_private_key_file = utils.get_from_config(args.accountName,
                                                          config,
                                                          region,
                                                          'ssh_private_key',
                                                          '--private-key-file')
-        # If key_pair_name and ssh_private_key_file are missing, a temporary key pair
-        # get's created. Otherwise both parameters are required.
-        if key_pair_name and not ssh_private_key_file:
-            print('Could not determine the private ssh key file', file=sys.stderr)
-            sys.exit(1)
-        if ssh_private_key_file and not key_pair_name:
-            print('Could not determine key pair name', file=sys.stderr)
-            sys.exit(1)
 
-        if ssh_private_key_file:
-            ssh_private_key_file = os.path.expanduser(ssh_private_key_file)
+        if not ssh_private_key_file:
+            print(
+                'Could not determine the private ssh key file',
+                file=sys.stderr
+            )
 
-            if not os.path.exists(ssh_private_key_file):
-                print(
-                    (
-                         'SSH private key file "%s" does not exist'
-                         % ssh_private_key_file
-                    ),
-                    file=sys.stderr
-                )
-                sys.exit(1)
+        ssh_private_key_file = os.path.expanduser(ssh_private_key_file)
+
+        if not os.path.exists(ssh_private_key_file):
+            print(
+                (
+                     'SSH private key file "%s" does not exist'
+                     % ssh_private_key_file
+                ),
+                file=sys.stderr
+            )
+            sys.exit(1)
 
         ssh_user = args.sshUser
         if not ssh_user:
@@ -485,6 +489,8 @@ try:
             sys.exit(1)
 
         vpc_subnet_id = args.vpcSubnetId
+        if not vpc_subnet_id and not args.accountName:
+            vpc_subnet_id = setup.create_vpc_subnet()
         if not vpc_subnet_id and not (args.amiID or args.runningID):
             # Depending on instance type an instance may possibly only
             # launch inside a subnet. Look in the config for a subnet if none
@@ -504,6 +510,10 @@ try:
                     msg += '"subnet_id_%s" value' % region
                     print(msg)
 
+        security_group_ids = args.securityGroupIds
+        if not security_group_ids:
+            security_group_ids = setup.create_security_group()
+
         uploader = ec2upimg.EC2ImageUploader(
                           access_key=access_key,
                           backing_store=args.backingStore,
@@ -521,7 +531,7 @@ try:
                           root_volume_size=root_volume_size,
                           running_id=running_id,
                           secret_key=secret_key,
-                          security_group_ids=args.securityGroupIds,
+                          security_group_ids=security_group_ids,
                           session_token=args.sessionToken,
                           sriov_type=sriov_type,
                           ssh_key_pair_name=key_pair_name,
@@ -549,3 +559,6 @@ except EC2UploadImgException as e:
 except Exception as e:
     print(format(e), file=sys.stderr)
     sys.exit(1)
+finally:
+    if setup:
+        setup.clean_up()

--- a/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
+++ b/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
@@ -26,7 +26,6 @@ import time
 
 from ec2utils.ec2utils import EC2Utils
 from ec2utils.ec2UtilsExceptions import EC2UploadImgException
-from tempfile import mkstemp
 
 
 class EC2ImageUploader(EC2Utils):
@@ -100,9 +99,6 @@ class EC2ImageUploader(EC2Utils):
         self.percent_transferred = 0
         self.ssh_client = None
         self.storage_volume_size = 2 * self.root_volume_size
-        self.temporary_key_created = False
-
-        self._prepare_aws_for_upload()
 
     # ---------------------------------------------------------------------
     def _attach_volume(self, volume, device=None):
@@ -240,12 +236,33 @@ class EC2ImageUploader(EC2Utils):
             self.ssh_client.close()
         if self.instance_ids:
             self._connect().terminate_instances(InstanceIds=self.instance_ids)
+            waiter = self._connect().get_waiter('instance_terminated')
+            repeat_count = 1
+            error_msg = 'Instance did not stop within allotted time'
+            while repeat_count <= self.wait_count:
+                try:
+                    wait_status = waiter.wait(
+                        InstanceIds=[self.helper_instance['InstanceId']],
+                        Filters=[
+                            {
+                                'Name': 'instance-state-name',
+                                'Values': ['terminated']
+                            }
+                        ]
+                    )
+                except:
+                    wait_status = 1
+                if self.verbose:
+                    self.progress_timer.cancel()
+                repeat_count = self._check_wait_status(
+                    wait_status,
+                    error_msg,
+                    repeat_count
+                )
         if self.created_volumes:
             for volume in self.created_volumes:
                 self._detach_volume(volume, True)
                 self._remove_volume(volume)
-        if self.temporary_key_created:
-            self._remove_upload_key_pair()
 
         self.created_volumes = []
         self.instance_ids = []
@@ -373,23 +390,6 @@ class EC2ImageUploader(EC2Utils):
         return self._create_volume('%s' % self.root_volume_size)
 
     # ---------------------------------------------------------------------
-    def _create_upload_key_pair(self, key_name='temporary_ec2_uploadkey'):
-        if self.verbose:
-            print('Creating temporary key pair')
-        home_dir = os.path.expanduser('~/')
-        fd, location = mkstemp(prefix='temporary_ec2_uploadkey.', suffix='.key', dir=home_dir)
-        self.ssh_key_pair_name = os.path.basename(location)
-        self.ssh_key_private_key_file = location
-        secret_key_content = self._connect().create_key_pair(KeyName=self.ssh_key_pair_name)
-        if self.verbose:
-            print('Created key pair: ', self.ssh_key_pair_name)
-        with open(location, 'w') as localfile:
-            localfile.write(secret_key_content['KeyMaterial'])
-        if self.verbose:
-            print('Wrote secret key key file to ', location)
-        os.close(fd)
-
-    # ---------------------------------------------------------------------
     def _create_volume(self, size):
         """Create a volume"""
         volume = self._connect().create_volume(
@@ -429,16 +429,6 @@ class EC2ImageUploader(EC2Utils):
         self.created_volumes.append(volume)
 
         return volume
-
-    # ---------------------------------------------------------------------
-    def _remove_upload_key_pair(self):
-        if self.verbose:
-            print('Deleting temporary key pair ', self.ssh_key_pair_name)
-        secret_key = self._connect().delete_key_pair(KeyName=self.ssh_key_pair_name)
-        if os.path.isfile(self.ssh_key_private_key_file):
-            os.remove(self.ssh_key_private_key_file)
-        if self.verbose:
-            print('Deleted temporary key ', self.ssh_key_private_key_file)
 
     # ---------------------------------------------------------------------
     def _detach_volume(self, volume, no_clean_up=False):
@@ -749,12 +739,6 @@ class EC2ImageUploader(EC2Utils):
         result = self._execute_ssh_command(command)
 
         return mount_point
-
-    # ---------------------------------------------------------------------
-    def _prepare_aws_for_upload(self):
-        if not self.ssh_key_private_key_file:
-            self._create_upload_key_pair()
-            self.temporary_key_created = True
 
     # ---------------------------------------------------------------------
     def _register_image(self, snapshot):

--- a/ec2utils/ec2utilsbase/lib/ec2utils/ec2setup.py
+++ b/ec2utils/ec2utilsbase/lib/ec2utils/ec2setup.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2018 SUSE LLC, Christian Bruckmayer <cbruckmayer@suse.com>
+#
+# This file is part of ec2utilsbase.
+#
+# ec2utilsbase is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ec2utilsbase is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ec2utilsbase.  If not, see <http://www.gnu.org/licenses/>.
+
+import boto3
+import os
+import random
+import datetime
+
+from ec2utils.ec2UtilsExceptions import EC2ConnectionException
+from ec2utils.ec2utils import EC2Utils
+from tempfile import mkstemp
+from tempfile import mkdtemp
+
+class EC2Setup(EC2Utils):
+    """Class to prepare an Amazon EC2 account with all necessary resources"""
+
+    def __init__(self, access_key, region, secret_key, session_token, verbose):
+        EC2Utils.__init__(self)
+        self.access_key = access_key
+        self.region = region
+        self.secret_key = secret_key
+        self.session_token = session_token
+        self.verbose = verbose
+
+        self.internet_gateway_id = ''
+        self.key_pair_name = ''
+        self.route_table_id = ''
+        self.security_group_id = ''
+        self.ssh_private_key_file = ''
+        self.temp_dir = ''
+        self.vpc_subnet_id = ''
+        self.vpc_id = ''
+
+    # ---------------------------------------------------------------------
+    def clean_up(self):
+        if self.key_pair_name:
+            self._remove_upload_key_pair()
+        if self.security_group_id:
+            self._remove_security_group()
+        if self.vpc_id:
+            self._remove_vpc()
+
+    # ---------------------------------------------------------------------
+    def create_security_group(self):
+        if self.verbose:
+            print('Creating temporary security group')
+        group_name = 'ec2uploadimg-%s' % (random.randint(1,100))
+        group_description = 'ec2uploadimg created %s' % datetime.datetime.now()
+        response = self._connect().create_security_group(GroupName=group_name,
+                                     Description=group_description,
+                                     VpcId=self.vpc_id)
+
+        self.security_group_id = response['GroupId']
+        if self.verbose:
+            print('Temporary Security Group Created %s in vpc %s' % (self.security_group_id, self.vpc_id))
+        data = self._connect().authorize_security_group_ingress(
+            GroupId=self.security_group_id,
+            IpPermissions=[
+                {'IpProtocol': 'tcp',
+                 'FromPort': 22,
+                 'ToPort': 22,
+                 'IpRanges': [{'CidrIp': '0.0.0.0/0'}]}
+            ])
+
+        if self.verbose:
+            print("Successfully allowed incoming SSH port 22 for security group %s in %s" % (self.security_group_id, self.vpc_id))
+        return self.security_group_id
+
+    # ---------------------------------------------------------------------
+    def create_upload_key_pair(self, key_name='temporary_ec2_uploadkey'):
+        if self.verbose:
+            print('Creating temporary key pair')
+        dir_path = os.path.expanduser('~/')
+        if not os.access(dir_path, os.W_OK):
+            dir_path = mkdtemp()
+            self.temp_dir = dir_path
+        fd, location = mkstemp(prefix='temporary_ec2_uploadkey.', suffix='.key', dir=dir_path)
+        self.key_pair_name = os.path.basename(location)
+        self.ssh_private_key_file = location
+        secret_key_content = self._connect().create_key_pair(KeyName=self.key_pair_name)
+        if self.verbose:
+            print('Successfully created key pair: ', self.key_pair_name)
+        with open(location, 'w') as localfile:
+            localfile.write(secret_key_content['KeyMaterial'])
+        if self.verbose:
+            print('Successfully wrote secret key key file to ', location)
+        os.close(fd)
+        return self.key_pair_name, self.ssh_private_key_file
+
+    # ---------------------------------------------------------------------
+    def create_vpc_subnet(self):
+        self._create_vpc()
+        self._create_internet_gateway()
+        self._create_route_table()
+        self._create_vpc_subnet()
+        return self.vpc_subnet_id
+
+    # ---------------------------------------------------------------------
+    def _create_internet_gateway(self):
+        response = self._connect().create_internet_gateway()
+        self.internet_gateway_id = response['InternetGateway']['InternetGatewayId']
+        self._connect().attach_internet_gateway(VpcId=self.vpc_id, InternetGatewayId=self.internet_gateway_id)
+        if self.verbose:
+            print("Successfully created internet gateway %s" % (self.internet_gateway_id))
+
+    # ---------------------------------------------------------------------
+    def _create_route_table(self):
+        response = self._connect().create_route_table(VpcId=self.vpc_id)
+        self.route_table_id = response['RouteTable']['RouteTableId']
+        self._connect().create_route(DestinationCidrBlock='0.0.0.0/0', GatewayId=self.internet_gateway_id, RouteTableId=self.route_table_id)
+        if self.verbose:
+            print("Successfully created route table %s" % (self.route_table_id))
+
+    # ---------------------------------------------------------------------
+    def _create_vpc(self):
+        vpc_name = 'uploader-%s' % (random.randint(1,100))
+        response = self._connect().create_vpc(CidrBlock='192.168.0.0/16')
+        self.vpc_id = response['Vpc']['VpcId']
+        self._connect().create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': vpc_name}])
+        if self.verbose:
+            print("Successfully created VPC with id %s" % (self.vpc_id))
+
+    # ---------------------------------------------------------------------
+    def _create_vpc_subnet(self):
+        response = self._connect().create_subnet(CidrBlock='192.168.1.0/24', VpcId=self.vpc_id)
+        self.vpc_subnet_id = response['Subnet']['SubnetId']
+        self._connect().associate_route_table(SubnetId=self.vpc_subnet_id, RouteTableId=self.route_table_id)
+        self._connect().modify_subnet_attribute(MapPublicIpOnLaunch={ 'Value': True }, SubnetId=self.vpc_subnet_id)
+        if self.verbose:
+            print("Successfully created VPC subnet with id %s" % (self.vpc_subnet_id))
+
+    # ---------------------------------------------------------------------
+    def _remove_security_group(self):
+        response = self._connect().delete_security_group(GroupId=self.security_group_id)
+        if self.verbose:
+            print('Successfully deleted security group %s', % self.security_group_id)
+
+    # ---------------------------------------------------------------------
+    def _remove_upload_key_pair(self):
+        if self.verbose:
+            print('Deleting temporary key pair ', self.key_pair_name)
+        secret_key = self._connect().delete_key_pair(KeyName=self.key_pair_name)
+        if os.path.isfile(self.ssh_private_key_file):
+            os.remove(self.ssh_private_key_file)
+        if self.temp_dir:
+            os.rmdir(self.temp_dir)
+        if self.verbose:
+            print('Successfully deleted temporary key ', self.ssh_private_key_file)
+
+    # ---------------------------------------------------------------------
+    def _remove_vpc(self):
+        self._connect().delete_route(DestinationCidrBlock='0.0.0.0/0', RouteTableId=self.route_table_id)
+        if self.verbose:
+            print('Successfully deleted route from route table %s', % self.route_table_id)
+        self._connect().delete_subnet(SubnetId=self.vpc_subnet_id)
+        if self.verbose:
+            print('Successfully deleted VPC subnet %s', % self.vpc_subnet_id)
+        self._connect().delete_route_table(RouteTableId=self.route_table_id)
+        if self.verbose:
+            print('Successfully deleted route table %s', % self.route_table_id)
+        self._connect().detach_internet_gateway(InternetGatewayId=self.internet_gateway_id, VpcId=self.vpc_id)
+        if self.verbose:
+            print('Successfully deleted detached internet gateway %s', % self.internet_gateway_id)
+        self._connect().delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+        if self.verbose:
+            print('Successfully deleted internet gateway %s', % self.internet_gateway_id)
+        self._connect().delete_vpc(VpcId=self.vpc_id)
+        if self.verbose:
+            print('Successfully deleted VPC %s', % self.vpc_id)


### PR DESCRIPTION
and move temporary key creation to it.
EC2Preparer#prepare will also create a temporary VPC and Security group with all dependencies.
This makes sure that all dependencies are already set up when calling EC2ImageUploader.

Instead of adding this functionality to the ec2utilsutils class I extracted a new EC2Preparer class to follow the single responsibility principle. Also this class contains a lot of data (like all the temporary assets it creates) which would bloat ec2utilsutils. @rjschwei let me know what you think, I'm open for your suggestions.