### PR TITLE
Extract EC2Setup class (new)

### DIFF
--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -360,213 +360,211 @@ if (
     print('--instance-id, or --boot-kernel', file=sys.stderr)
     sys.exit(1)
 
-setup = None
-
 try:
     ami_id = args.amiID
     running_id = args.runningID
     for region in regions:
-        setup = EC2Setup(access_key, region, secret_key, args.sessionToken,
-                         args.verbose)
-        if not ami_id and not running_id:
-            try:
-                ami_id = utils.get_from_config(args.accountName,
-                                               config,
-                                               region,
-                                               'ami',
-                                               '--ec2-ami')
-            except:
-                print('Could not determine helper AMI-ID', file=sys.stderr)
-                sys.exit(1)
-        bootkernel = args.akiID
-        if args.virtType == 'hvm':
-            bootkernel = None
-
-        if not bootkernel and args.virtType != 'hvm':
-            if args.grub2:
+        try:
+            setup = EC2Setup(access_key, region, secret_key, args.sessionToken,
+                             args.verbose)
+            if not ami_id and not running_id:
                 try:
-                    bootkernel = utils.get_from_config(args.accountName,
-                                                       config,
-                                                       region,
-                                                       'g2_aki_x86_64',
-                                                       '--boot-kernel')
+                    ami_id = utils.get_from_config(args.accountName,
+                                                   config,
+                                                   region,
+                                                   'ami',
+                                                   '--ec2-ami')
                 except:
+                    print('Could not determine helper AMI-ID', file=sys.stderr)
+                    sys.exit(1)
+            bootkernel = args.akiID
+            if args.virtType == 'hvm':
+                bootkernel = None
+
+            if not bootkernel and args.virtType != 'hvm':
+                if args.grub2:
+                    try:
+                        bootkernel = utils.get_from_config(args.accountName,
+                                                           config,
+                                                           region,
+                                                           'g2_aki_x86_64',
+                                                           '--boot-kernel')
+                    except:
+                        print(
+                            'Could not find bootkernel in config',
+                            file=sys.stderr
+                        )
+                        sys.exit(1)
+                elif args.arch == 'x86_64':
+                    try:
+                        bootkernel = utils.get_from_config(args.accountName,
+                                                           config,
+                                                           region,
+                                                           'aki_x86_64',
+                                                           '--boot-kernel')
+                    except:
+                        print(
+                            'Could not find bootkernel in config',
+                            file=sys.stderr
+                        )
+                        sys.exit(1)
+                elif args.arch == 'i386':
+                    try:
+                        bootkernel = utils.get_from_config(args.accountName,
+                                                           config,
+                                                           region,
+                                                           'aki_i386',
+                                                           '--boot-kernel')
+                    except:
+                        print(
+                            'Could not find bootkernel in config',
+                            file=sys.stderr
+                        )
+                        sys.exit(1)
+                else:
                     print(
-                        'Could not find bootkernel in config',
+                        'Could not reliably determine the ',
+                        end=' ',
                         file=sys.stderr
                     )
+                    print('bootkernel to use ', file=sys.stderr)
+                    print('must specify bootkernel, ', end=' ', file=sys.stderr)
+                    print('arch (x86_64|i386) or hvm', file=sys.stderr)
                     sys.exit(1)
-            elif args.arch == 'x86_64':
-                try:
-                    bootkernel = utils.get_from_config(args.accountName,
-                                                       config,
-                                                       region,
-                                                       'aki_x86_64',
-                                                       '--boot-kernel')
-                except:
-                    print(
-                        'Could not find bootkernel in config',
-                        file=sys.stderr
-                    )
-                    sys.exit(1)
-            elif args.arch == 'i386':
-                try:
-                    bootkernel = utils.get_from_config(args.accountName,
-                                                       config,
-                                                       region,
-                                                       'aki_i386',
-                                                       '--boot-kernel')
-                except:
-                    print(
-                        'Could not find bootkernel in config',
-                        file=sys.stderr
-                    )
-                    sys.exit(1)
-            else:
-                print(
-                    'Could not reliably determine the ',
-                    end=' ',
-                    file=sys.stderr
-                )
-                print('bootkernel to use ', file=sys.stderr)
-                print('must specify bootkernel, ', end=' ', file=sys.stderr)
-                print('arch (x86_64|i386) or hvm', file=sys.stderr)
-                sys.exit(1)
 
-        inst_type = args.instType
-        if not inst_type:
-            inst_type = utils.get_from_config(args.accountName,
-                                              config,
-                                              region,
-                                              'instance_type',
-                                              '--type')
-
-        key_pair_name = args.sshName
-        ssh_private_key_file = args.privateKey
-        if (
-            not key_pair_name
-            and not ssh_private_key_file
-            and not args.accountName
-           ):
-            key_pair_name, ssh_private_key_file = \
-                setup.create_upload_key_pair()
-        if not key_pair_name:
-            key_pair_name = utils.get_from_config(args.accountName,
+            inst_type = args.instType
+            if not inst_type:
+                inst_type = utils.get_from_config(args.accountName,
                                                   config,
                                                   region,
-                                                  'ssh_key_name',
-                                                  '--ssh-key-pair')
-        if not key_pair_name:
-            print('Could not determine key pair name', file=sys.stderr)
-            sys.exit(1)
+                                                  'instance_type',
+                                                  '--type')
 
-        if not ssh_private_key_file:
-            ssh_private_key_file = utils.get_from_config(args.accountName,
-                                                         config,
-                                                         region,
-                                                         'ssh_private_key',
-                                                         '--private-key-file')
-
-        if not ssh_private_key_file:
-            print(
-                'Could not determine the private ssh key file',
-                file=sys.stderr
-            )
-
-        ssh_private_key_file = os.path.expanduser(ssh_private_key_file)
-
-        if not os.path.exists(ssh_private_key_file):
-            print(
-                (
-                     'SSH private key file "%s" does not exist'
-                     % ssh_private_key_file
-                ),
-                file=sys.stderr
-            )
-            sys.exit(1)
-
-        ssh_user = args.sshUser
-        if not ssh_user:
-            ssh_user = utils.get_from_config(args.accountName,
-                                             config,
-                                             region,
-                                             'user',
-                                             '--user')
-        if not ssh_user:
-            print('Could not determin ssh user to use', file=sys.stderr)
-            sys.exit(1)
-
-        vpc_subnet_id = args.vpcSubnetId
-        if not vpc_subnet_id and not args.accountName:
-            vpc_subnet_id = setup.create_vpc_subnet()
-        if not vpc_subnet_id and not (args.amiID or args.runningID):
-            # Depending on instance type an instance may possibly only
-            # launch inside a subnet. Look in the config for a subnet if none
-            # is given and the AMI to use was not specified on the command line
-            try:
-                vpc_subnet_id = utils.get_from_config(args.accountName,
+            key_pair_name = args.sshName
+            ssh_private_key_file = args.privateKey
+            if (
+                not key_pair_name
+                and not ssh_private_key_file
+                and not args.accountName
+               ):
+                key_pair_name, ssh_private_key_file = \
+                    setup.create_upload_key_pair()
+            if not key_pair_name:
+                key_pair_name = utils.get_from_config(args.accountName,
                                                       config,
                                                       region,
-                                                      'subnet_id_%s' % region,
-                                                      '--vpc-subnet-id')
-                if args.verbose and vpc_subnet_id:
-                    print('Using VPC subnet: %s' % vpc_subnet_id)
-            except:
-                if args.verbose:
-                    msg = 'Not using a subnet-id, none given on the '
-                    msg += 'command line and none found in config for '
-                    msg += '"subnet_id_%s" value' % region
-                    print(msg)
+                                                      'ssh_key_name',
+                                                      '--ssh-key-pair')
+            if not key_pair_name:
+                print('Could not determine key pair name', file=sys.stderr)
+                sys.exit(1)
 
-        security_group_ids = args.securityGroupIds
-        if not security_group_ids:
-            security_group_ids = setup.create_security_group()
+            if not ssh_private_key_file:
+                ssh_private_key_file = utils.get_from_config(args.accountName,
+                                                             config,
+                                                             region,
+                                                             'ssh_private_key',
+                                                             '--private-key-file')
 
-        uploader = ec2upimg.EC2ImageUploader(
-                          access_key=access_key,
-                          backing_store=args.backingStore,
-                          billing_codes=args.billingCodes,
-                          bootkernel=bootkernel,
-                          ena_support=args.ena,
-                          image_arch=args.arch,
-                          image_description=args.descript,
-                          image_name=args.imgName,
-                          image_virt_type=virtualization_type,
-                          inst_user_name=ssh_user,
-                          launch_ami=ami_id,
-                          launch_inst_type=inst_type,
-                          region=region,
-                          root_volume_size=root_volume_size,
-                          running_id=running_id,
-                          secret_key=secret_key,
-                          security_group_ids=security_group_ids,
-                          session_token=args.sessionToken,
-                          sriov_type=sriov_type,
-                          ssh_key_pair_name=key_pair_name,
-                          ssh_key_private_key_file=ssh_private_key_file,
-                          ssh_timeout=args.sshTimeout,
-                          use_grub2=args.grub2,
-                          use_private_ip=args.usePrivateIP,
-                          verbose=args.verbose,
-                          vpc_subnet_id=vpc_subnet_id,
-                          wait_count=args.waitCount
-        )
+            if not ssh_private_key_file:
+                print(
+                    'Could not determine the private ssh key file',
+                    file=sys.stderr
+                )
 
-        if args.snapOnly:
-            snapshot = uploader.create_snapshot(args.source)
-            print('Created snapshot: ', snapshot['SnapshotId'])
-        elif args.rootSwapMethod:
-            ami = uploader.create_image_use_root_swap(args.source)
-            print('Created image: ', ami)
-        else:
-            ami = uploader.create_image(args.source)
-            print('Created image: ', ami)
+            ssh_private_key_file = os.path.expanduser(ssh_private_key_file)
+
+            if not os.path.exists(ssh_private_key_file):
+                print(
+                    (
+                         'SSH private key file "%s" does not exist'
+                         % ssh_private_key_file
+                    ),
+                    file=sys.stderr
+                )
+                sys.exit(1)
+
+            ssh_user = args.sshUser
+            if not ssh_user:
+                ssh_user = utils.get_from_config(args.accountName,
+                                                 config,
+                                                 region,
+                                                 'user',
+                                                 '--user')
+            if not ssh_user:
+                print('Could not determin ssh user to use', file=sys.stderr)
+                sys.exit(1)
+
+            vpc_subnet_id = args.vpcSubnetId
+            if not vpc_subnet_id and not args.accountName:
+                vpc_subnet_id = setup.create_vpc_subnet()
+            if not vpc_subnet_id and not (args.amiID or args.runningID):
+                # Depending on instance type an instance may possibly only
+                # launch inside a subnet. Look in the config for a subnet if none
+                # is given and the AMI to use was not specified on the command line
+                try:
+                    vpc_subnet_id = utils.get_from_config(args.accountName,
+                                                          config,
+                                                          region,
+                                                          'subnet_id_%s' % region,
+                                                          '--vpc-subnet-id')
+                    if args.verbose and vpc_subnet_id:
+                        print('Using VPC subnet: %s' % vpc_subnet_id)
+                except:
+                    if args.verbose:
+                        msg = 'Not using a subnet-id, none given on the '
+                        msg += 'command line and none found in config for '
+                        msg += '"subnet_id_%s" value' % region
+                        print(msg)
+
+            security_group_ids = args.securityGroupIds
+            if not security_group_ids:
+                security_group_ids = setup.create_security_group()
+
+            uploader = ec2upimg.EC2ImageUploader(
+                              access_key=access_key,
+                              backing_store=args.backingStore,
+                              billing_codes=args.billingCodes,
+                              bootkernel=bootkernel,
+                              ena_support=args.ena,
+                              image_arch=args.arch,
+                              image_description=args.descript,
+                              image_name=args.imgName,
+                              image_virt_type=virtualization_type,
+                              inst_user_name=ssh_user,
+                              launch_ami=ami_id,
+                              launch_inst_type=inst_type,
+                              region=region,
+                              root_volume_size=root_volume_size,
+                              running_id=running_id,
+                              secret_key=secret_key,
+                              security_group_ids=security_group_ids,
+                              session_token=args.sessionToken,
+                              sriov_type=sriov_type,
+                              ssh_key_pair_name=key_pair_name,
+                              ssh_key_private_key_file=ssh_private_key_file,
+                              ssh_timeout=args.sshTimeout,
+                              use_grub2=args.grub2,
+                              use_private_ip=args.usePrivateIP,
+                              verbose=args.verbose,
+                              vpc_subnet_id=vpc_subnet_id,
+                              wait_count=args.waitCount
+            )
+
+            if args.snapOnly:
+                snapshot = uploader.create_snapshot(args.source)
+                print('Created snapshot: ', snapshot['SnapshotId'])
+            elif args.rootSwapMethod:
+                ami = uploader.create_image_use_root_swap(args.source)
+                print('Created image: ', ami)
+            else:
+                ami = uploader.create_image(args.source)
+                print('Created image: ', ami)
+        finally:
+            setup.clean_up()
 except EC2UploadImgException as e:
     print(format(e), file=sys.stderr)
     sys.exit(1)
 except Exception as e:
     print(format(e), file=sys.stderr)
     sys.exit(1)
-finally:
-    if setup:
-        setup.clean_up()

--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -360,12 +360,14 @@ if (
     print('--instance-id, or --boot-kernel', file=sys.stderr)
     sys.exit(1)
 
-setup = EC2Setup(access_key, region, secret_key, args.sessionToken,
-                 args.verbose)
+setup = None
+
 try:
     ami_id = args.amiID
     running_id = args.runningID
     for region in regions:
+        setup = EC2Setup(access_key, region, secret_key, args.sessionToken,
+                         args.verbose)
         if not ami_id and not running_id:
             try:
                 ami_id = utils.get_from_config(args.accountName,
@@ -563,4 +565,5 @@ except Exception as e:
     print(format(e), file=sys.stderr)
     sys.exit(1)
 finally:
-    setup.clean_up()
+    if setup:
+        setup.clean_up()

--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -346,9 +346,9 @@ if args.rootVolSize:
 
 regions = args.regions.split(',')
 if (
-        len(regions) > 1
-        and (args.amiID or args.akiID or args.runningID or args.vpcSubnetId)
-):
+    len(regions) > 1 and (args.amiID or args.akiID or args.runningID or
+                          args.vpcSubnetId)
+   ):
     print(
         'Incompatible arguments: multiple regions specified',
         file=sys.stderr
@@ -360,7 +360,8 @@ if (
     print('--instance-id, or --boot-kernel', file=sys.stderr)
     sys.exit(1)
 
-setup = EC2Setup(access_key, region, secret_key, args.sessionToken, args.verbose)
+setup = EC2Setup(access_key, region, secret_key, args.sessionToken,
+                 args.verbose)
 try:
     ami_id = args.amiID
     running_id = args.runningID
@@ -440,8 +441,10 @@ try:
 
         key_pair_name = args.sshName
         ssh_private_key_file = args.privateKey
-        if not key_name and not ssh_private_key_file and not args.accountName:
-            key_pair_name, ssh_private_key_file = setup.create_upload_key_pair()
+        if not key_pair_name and not ssh_private_key_file and not \
+                args.accountName:
+            key_pair_name, ssh_private_key_file = \
+                setup.create_upload_key_pair()
         if not key_pair_name:
             key_pair_name = utils.get_from_config(args.accountName,
                                                   config,

--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -26,6 +26,7 @@ import sys
 import ec2utils.ec2utilsutils as utils
 import ec2utils.ec2uploadimg as ec2upimg
 from ec2utils.ec2UtilsExceptions import *
+from ec2utils.ec2setup import EC2Setup
 
 # Set up command line argument parsing
 argparse = argparse.ArgumentParser(description='Upload image to Amazon EC2')
@@ -359,6 +360,7 @@ if (
     print('--instance-id, or --boot-kernel', file=sys.stderr)
     sys.exit(1)
 
+setup = EC2Setup(access_key, region, secret_key, args.sessionToken, args.verbose)
 try:
     ami_id = args.amiID
     running_id = args.runningID
@@ -437,41 +439,43 @@ try:
                                               '--type')
 
         key_pair_name = args.sshName
+        ssh_private_key_file = args.privateKey
+        if not key_name and not ssh_private_key_file and not args.accountName:
+            key_pair_name, ssh_private_key_file = setup.create_upload_key_pair()
         if not key_pair_name:
             key_pair_name = utils.get_from_config(args.accountName,
                                                   config,
                                                   region,
                                                   'ssh_key_name',
                                                   '--ssh-key-pair')
+        if not key_pair_name:
+            print('Could not determine key pair name', file=sys.stderr)
+            sys.exit(1)
 
-        ssh_private_key_file = args.privateKey
         if not ssh_private_key_file:
             ssh_private_key_file = utils.get_from_config(args.accountName,
                                                          config,
                                                          region,
                                                          'ssh_private_key',
                                                          '--private-key-file')
-        # If key_pair_name and ssh_private_key_file are missing, a temporary key pair
-        # get's created. Otherwise both parameters are required.
-        if key_pair_name and not ssh_private_key_file:
-            print('Could not determine the private ssh key file', file=sys.stderr)
-            sys.exit(1)
-        if ssh_private_key_file and not key_pair_name:
-            print('Could not determine key pair name', file=sys.stderr)
-            sys.exit(1)
 
-        if ssh_private_key_file:
-            ssh_private_key_file = os.path.expanduser(ssh_private_key_file)
+        if not ssh_private_key_file:
+            print(
+                'Could not determine the private ssh key file',
+                file=sys.stderr
+            )
 
-            if not os.path.exists(ssh_private_key_file):
-                print(
-                    (
-                         'SSH private key file "%s" does not exist'
-                         % ssh_private_key_file
-                    ),
-                    file=sys.stderr
-                )
-                sys.exit(1)
+        ssh_private_key_file = os.path.expanduser(ssh_private_key_file)
+
+        if not os.path.exists(ssh_private_key_file):
+            print(
+                (
+                     'SSH private key file "%s" does not exist'
+                     % ssh_private_key_file
+                ),
+                file=sys.stderr
+            )
+            sys.exit(1)
 
         ssh_user = args.sshUser
         if not ssh_user:
@@ -485,6 +489,8 @@ try:
             sys.exit(1)
 
         vpc_subnet_id = args.vpcSubnetId
+        if not vpc_subnet_id and not args.accountName:
+            vpc_subnet_id = setup.create_vpc_subnet()
         if not vpc_subnet_id and not (args.amiID or args.runningID):
             # Depending on instance type an instance may possibly only
             # launch inside a subnet. Look in the config for a subnet if none
@@ -504,6 +510,10 @@ try:
                     msg += '"subnet_id_%s" value' % region
                     print(msg)
 
+        security_group_ids = args.securityGroupIds
+        if not security_group_ids:
+            security_group_ids = setup.create_security_group()
+
         uploader = ec2upimg.EC2ImageUploader(
                           access_key=access_key,
                           backing_store=args.backingStore,
@@ -521,7 +531,7 @@ try:
                           root_volume_size=root_volume_size,
                           running_id=running_id,
                           secret_key=secret_key,
-                          security_group_ids=args.securityGroupIds,
+                          security_group_ids=security_group_ids,
                           session_token=args.sessionToken,
                           sriov_type=sriov_type,
                           ssh_key_pair_name=key_pair_name,
@@ -549,3 +559,6 @@ except EC2UploadImgException as e:
 except Exception as e:
     print(format(e), file=sys.stderr)
     sys.exit(1)
+finally:
+    if setup:
+        setup.clean_up()

--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -563,5 +563,4 @@ except Exception as e:
     print(format(e), file=sys.stderr)
     sys.exit(1)
 finally:
-    if setup:
-        setup.clean_up()
+    setup.clean_up()

--- a/ec2utils/ec2uploadimg/ec2uploadimg
+++ b/ec2utils/ec2uploadimg/ec2uploadimg
@@ -443,8 +443,11 @@ try:
 
         key_pair_name = args.sshName
         ssh_private_key_file = args.privateKey
-        if not key_pair_name and not ssh_private_key_file and not \
-                args.accountName:
+        if (
+            not key_pair_name
+            and not ssh_private_key_file
+            and not args.accountName
+           ):
             key_pair_name, ssh_private_key_file = \
                 setup.create_upload_key_pair()
         if not key_pair_name:

--- a/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
+++ b/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
@@ -26,7 +26,6 @@ import time
 
 from ec2utils.ec2utils import EC2Utils
 from ec2utils.ec2UtilsExceptions import EC2UploadImgException
-from tempfile import mkstemp
 
 
 class EC2ImageUploader(EC2Utils):
@@ -100,9 +99,6 @@ class EC2ImageUploader(EC2Utils):
         self.percent_transferred = 0
         self.ssh_client = None
         self.storage_volume_size = 2 * self.root_volume_size
-        self.temporary_key_created = False
-
-        self._prepare_aws_for_upload()
 
     # ---------------------------------------------------------------------
     def _attach_volume(self, volume, device=None):
@@ -240,12 +236,33 @@ class EC2ImageUploader(EC2Utils):
             self.ssh_client.close()
         if self.instance_ids:
             self._connect().terminate_instances(InstanceIds=self.instance_ids)
+            waiter = self._connect().get_waiter('instance_terminated')
+            repeat_count = 1
+            error_msg = 'Instance did not stop within allotted time'
+            while repeat_count <= self.wait_count:
+                try:
+                    wait_status = waiter.wait(
+                        InstanceIds=[self.helper_instance['InstanceId']],
+                        Filters=[
+                            {
+                                'Name': 'instance-state-name',
+                                'Values': ['terminated']
+                            }
+                        ]
+                    )
+                except:
+                    wait_status = 1
+                if self.verbose:
+                    self.progress_timer.cancel()
+                repeat_count = self._check_wait_status(
+                    wait_status,
+                    error_msg,
+                    repeat_count
+                )
         if self.created_volumes:
             for volume in self.created_volumes:
                 self._detach_volume(volume, True)
                 self._remove_volume(volume)
-        if self.temporary_key_created:
-            self._remove_upload_key_pair()
 
         self.created_volumes = []
         self.instance_ids = []
@@ -373,23 +390,6 @@ class EC2ImageUploader(EC2Utils):
         return self._create_volume('%s' % self.root_volume_size)
 
     # ---------------------------------------------------------------------
-    def _create_upload_key_pair(self, key_name='temporary_ec2_uploadkey'):
-        if self.verbose:
-            print('Creating temporary key pair')
-        home_dir = os.path.expanduser('~/')
-        fd, location = mkstemp(prefix='temporary_ec2_uploadkey.', suffix='.key', dir=home_dir)
-        self.ssh_key_pair_name = os.path.basename(location)
-        self.ssh_key_private_key_file = location
-        secret_key_content = self._connect().create_key_pair(KeyName=self.ssh_key_pair_name)
-        if self.verbose:
-            print('Created key pair: ', self.ssh_key_pair_name)
-        with open(location, 'w') as localfile:
-            localfile.write(secret_key_content['KeyMaterial'])
-        if self.verbose:
-            print('Wrote secret key key file to ', location)
-        os.close(fd)
-
-    # ---------------------------------------------------------------------
     def _create_volume(self, size):
         """Create a volume"""
         volume = self._connect().create_volume(
@@ -429,16 +429,6 @@ class EC2ImageUploader(EC2Utils):
         self.created_volumes.append(volume)
 
         return volume
-
-    # ---------------------------------------------------------------------
-    def _remove_upload_key_pair(self):
-        if self.verbose:
-            print('Deleting temporary key pair ', self.ssh_key_pair_name)
-        secret_key = self._connect().delete_key_pair(KeyName=self.ssh_key_pair_name)
-        if os.path.isfile(self.ssh_key_private_key_file):
-            os.remove(self.ssh_key_private_key_file)
-        if self.verbose:
-            print('Deleted temporary key ', self.ssh_key_private_key_file)
 
     # ---------------------------------------------------------------------
     def _detach_volume(self, volume, no_clean_up=False):
@@ -749,12 +739,6 @@ class EC2ImageUploader(EC2Utils):
         result = self._execute_ssh_command(command)
 
         return mount_point
-
-    # ---------------------------------------------------------------------
-    def _prepare_aws_for_upload(self):
-        if not self.ssh_key_private_key_file:
-            self._create_upload_key_pair()
-            self.temporary_key_created = True
 
     # ---------------------------------------------------------------------
     def _register_image(self, snapshot):

--- a/ec2utils/ec2utilsbase/lib/ec2utils/ec2setup.py
+++ b/ec2utils/ec2utilsbase/lib/ec2utils/ec2setup.py
@@ -147,7 +147,7 @@ class EC2Setup(EC2Utils):
     def _remove_security_group(self):
         response = self._connect().delete_security_group(GroupId=self.security_group_id)
         if self.verbose:
-            print('Successfully deleted security group %s', % self.security_group_id)
+            print('Successfully deleted security group %s' % self.security_group_id)
 
     # ---------------------------------------------------------------------
     def _remove_upload_key_pair(self):
@@ -165,19 +165,19 @@ class EC2Setup(EC2Utils):
     def _remove_vpc(self):
         self._connect().delete_route(DestinationCidrBlock='0.0.0.0/0', RouteTableId=self.route_table_id)
         if self.verbose:
-            print('Successfully deleted route from route table %s', % self.route_table_id)
+            print('Successfully deleted route from route table %s' % self.route_table_id)
         self._connect().delete_subnet(SubnetId=self.vpc_subnet_id)
         if self.verbose:
-            print('Successfully deleted VPC subnet %s', % self.vpc_subnet_id)
+            print('Successfully deleted VPC subnet %s' % self.vpc_subnet_id)
         self._connect().delete_route_table(RouteTableId=self.route_table_id)
         if self.verbose:
-            print('Successfully deleted route table %s', % self.route_table_id)
+            print('Successfully deleted route table %s' % self.route_table_id)
         self._connect().detach_internet_gateway(InternetGatewayId=self.internet_gateway_id, VpcId=self.vpc_id)
         if self.verbose:
-            print('Successfully deleted detached internet gateway %s', % self.internet_gateway_id)
+            print('Successfully deleted detached internet gateway %s' % self.internet_gateway_id)
         self._connect().delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
         if self.verbose:
-            print('Successfully deleted internet gateway %s', % self.internet_gateway_id)
+            print('Successfully deleted internet gateway %s' % self.internet_gateway_id)
         self._connect().delete_vpc(VpcId=self.vpc_id)
         if self.verbose:
-            print('Successfully deleted VPC %s', % self.vpc_id)
+            print('Successfully deleted VPC %s' % self.vpc_id)

--- a/ec2utils/ec2utilsbase/lib/ec2utils/ec2setup.py
+++ b/ec2utils/ec2utilsbase/lib/ec2utils/ec2setup.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2018 SUSE LLC, Christian Bruckmayer <cbruckmayer@suse.com>
+#
+# This file is part of ec2utilsbase.
+#
+# ec2utilsbase is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ec2utilsbase is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ec2utilsbase.  If not, see <http://www.gnu.org/licenses/>.
+
+import boto3
+import os
+import random
+import datetime
+
+from ec2utils.ec2UtilsExceptions import EC2ConnectionException
+from ec2utils.ec2utils import EC2Utils
+from tempfile import mkstemp
+from tempfile import mkdtemp
+
+class EC2Setup(EC2Utils):
+    """Class to prepare an Amazon EC2 account with all necessary resources"""
+
+    def __init__(self, access_key, region, secret_key, session_token, verbose):
+        EC2Utils.__init__(self)
+        self.access_key = access_key
+        self.region = region
+        self.secret_key = secret_key
+        self.session_token = session_token
+        self.verbose = verbose
+
+        self.internet_gateway_id = ''
+        self.key_pair_name = ''
+        self.route_table_id = ''
+        self.security_group_id = ''
+        self.ssh_private_key_file = ''
+        self.temp_dir = ''
+        self.vpc_subnet_id = ''
+        self.vpc_id = ''
+
+    # ---------------------------------------------------------------------
+    def clean_up(self):
+        if self.key_pair_name:
+            self._remove_upload_key_pair()
+        if self.security_group_id:
+            self._remove_security_group()
+        if self.vpc_id:
+            self._remove_vpc()
+
+    # ---------------------------------------------------------------------
+    def create_security_group(self):
+        if self.verbose:
+            print('Creating temporary security group')
+        group_name = 'ec2uploadimg-%s' % (random.randint(1,100))
+        group_description = 'ec2uploadimg created %s' % datetime.datetime.now()
+        response = self._connect().create_security_group(GroupName=group_name,
+                                     Description=group_description,
+                                     VpcId=self.vpc_id)
+
+        self.security_group_id = response['GroupId']
+        if self.verbose:
+            print('Temporary Security Group Created %s in vpc %s' % (self.security_group_id, self.vpc_id))
+        data = self._connect().authorize_security_group_ingress(
+            GroupId=self.security_group_id,
+            IpPermissions=[
+                {'IpProtocol': 'tcp',
+                 'FromPort': 22,
+                 'ToPort': 22,
+                 'IpRanges': [{'CidrIp': '0.0.0.0/0'}]}
+            ])
+
+        if self.verbose:
+            print("Successfully allowed incoming SSH port 22 for security group %s in %s" % (self.security_group_id, self.vpc_id))
+        return self.security_group_id
+
+    # ---------------------------------------------------------------------
+    def create_upload_key_pair(self, key_name='temporary_ec2_uploadkey'):
+        if self.verbose:
+            print('Creating temporary key pair')
+        dir_path = os.path.expanduser('~/')
+        if not os.access(dir_path, os.W_OK):
+            dir_path = mkdtemp()
+            self.temp_dir = dir_path
+        fd, location = mkstemp(prefix='temporary_ec2_uploadkey.', suffix='.key', dir=dir_path)
+        self.key_pair_name = os.path.basename(location)
+        self.ssh_private_key_file = location
+        secret_key_content = self._connect().create_key_pair(KeyName=self.key_pair_name)
+        if self.verbose:
+            print('Successfully created key pair: ', self.key_pair_name)
+        with open(location, 'w') as localfile:
+            localfile.write(secret_key_content['KeyMaterial'])
+        if self.verbose:
+            print('Successfully wrote secret key key file to ', location)
+        os.close(fd)
+        return self.key_pair_name, self.ssh_private_key_file
+
+    # ---------------------------------------------------------------------
+    def create_vpc_subnet(self):
+        self._create_vpc()
+        self._create_internet_gateway()
+        self._create_route_table()
+        self._create_vpc_subnet()
+        return self.vpc_subnet_id
+
+    # ---------------------------------------------------------------------
+    def _create_internet_gateway(self):
+        response = self._connect().create_internet_gateway()
+        self.internet_gateway_id = response['InternetGateway']['InternetGatewayId']
+        self._connect().attach_internet_gateway(VpcId=self.vpc_id, InternetGatewayId=self.internet_gateway_id)
+        if self.verbose:
+            print("Successfully created internet gateway %s" % (self.internet_gateway_id))
+
+    # ---------------------------------------------------------------------
+    def _create_route_table(self):
+        response = self._connect().create_route_table(VpcId=self.vpc_id)
+        self.route_table_id = response['RouteTable']['RouteTableId']
+        self._connect().create_route(DestinationCidrBlock='0.0.0.0/0', GatewayId=self.internet_gateway_id, RouteTableId=self.route_table_id)
+        if self.verbose:
+            print("Successfully created route table %s" % (self.route_table_id))
+
+    # ---------------------------------------------------------------------
+    def _create_vpc(self):
+        vpc_name = 'uploader-%s' % (random.randint(1,100))
+        response = self._connect().create_vpc(CidrBlock='192.168.0.0/16')
+        self.vpc_id = response['Vpc']['VpcId']
+        self._connect().create_tags(Resources=[self.vpc_id], Tags=[{'Key': 'Name', 'Value': vpc_name}])
+        if self.verbose:
+            print("Successfully created VPC with id %s" % (self.vpc_id))
+
+    # ---------------------------------------------------------------------
+    def _create_vpc_subnet(self):
+        response = self._connect().create_subnet(CidrBlock='192.168.1.0/24', VpcId=self.vpc_id)
+        self.vpc_subnet_id = response['Subnet']['SubnetId']
+        self._connect().associate_route_table(SubnetId=self.vpc_subnet_id, RouteTableId=self.route_table_id)
+        self._connect().modify_subnet_attribute(MapPublicIpOnLaunch={ 'Value': True }, SubnetId=self.vpc_subnet_id)
+        if self.verbose:
+            print("Successfully created VPC subnet with id %s" % (self.vpc_subnet_id))
+
+    # ---------------------------------------------------------------------
+    def _remove_security_group(self):
+        response = self._connect().delete_security_group(GroupId=self.security_group_id)
+        if self.verbose:
+            print('Successfully deleted security group %s', % self.security_group_id)
+
+    # ---------------------------------------------------------------------
+    def _remove_upload_key_pair(self):
+        if self.verbose:
+            print('Deleting temporary key pair ', self.key_pair_name)
+        secret_key = self._connect().delete_key_pair(KeyName=self.key_pair_name)
+        if os.path.isfile(self.ssh_private_key_file):
+            os.remove(self.ssh_private_key_file)
+        if self.temp_dir:
+            os.rmdir(self.temp_dir)
+        if self.verbose:
+            print('Successfully deleted temporary key ', self.ssh_private_key_file)
+
+    # ---------------------------------------------------------------------
+    def _remove_vpc(self):
+        self._connect().delete_route(DestinationCidrBlock='0.0.0.0/0', RouteTableId=self.route_table_id)
+        if self.verbose:
+            print('Successfully deleted route from route table %s', % self.route_table_id)
+        self._connect().delete_subnet(SubnetId=self.vpc_subnet_id)
+        if self.verbose:
+            print('Successfully deleted VPC subnet %s', % self.vpc_subnet_id)
+        self._connect().delete_route_table(RouteTableId=self.route_table_id)
+        if self.verbose:
+            print('Successfully deleted route table %s', % self.route_table_id)
+        self._connect().detach_internet_gateway(InternetGatewayId=self.internet_gateway_id, VpcId=self.vpc_id)
+        if self.verbose:
+            print('Successfully deleted detached internet gateway %s', % self.internet_gateway_id)
+        self._connect().delete_internet_gateway(InternetGatewayId=self.internet_gateway_id)
+        if self.verbose:
+            print('Successfully deleted internet gateway %s', % self.internet_gateway_id)
+        self._connect().delete_vpc(VpcId=self.vpc_id)
+        if self.verbose:
+            print('Successfully deleted VPC %s', % self.vpc_id)


### PR DESCRIPTION
and move temporary key creation to it.
EC2Preparer#prepare will also create a temporary VPC and Security group with all dependencies.
This makes sure that all dependencies are already set up when calling EC2ImageUploader.

Instead of adding this functionality to the ec2utilsutils class I extracted a new EC2Preparer class to follow the single responsibility principle. Also this class contains a lot of data (like all the temporary assets it creates) which would bloat ec2utilsutils. @rjschwei let me know what you think, I'm open for your suggestions.

_________

@rjschwei I addressed all pep8 issues and fixed a syntax error. Please have a look again. I will squash the commits before the merge. It's just for you to see what has changed.

Both files were put through `pep8`.

_________

Closes #187 