### PR TITLE
- regionService

### DIFF
--- a/regionService/cloud-regionsrv.spec
+++ b/regionService/cloud-regionsrv.spec
@@ -2,7 +2,7 @@
 # spec file for package cloud-regionsrv
 # this code base is under development
 #
-# Copyright (c) 2016 SUSE LLC
+# Copyright (c) 2018 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 #
 
 Name:           cloud-regionsrv
-Version:        8.0.0
+Version:        8.0.1
 Release:        0
 License:        GPL-3.0+
 Summary:        Cloud Environment Region Service

--- a/regionService/srv/www/regionService/regionInfo.py
+++ b/regionService/srv/www/regionService/regionInfo.py
@@ -152,12 +152,12 @@ def find_longest_prefix_ipv4(requester, ip_range_map):
         3: []
     }
     results_map = {}
-    requester_prts = requester.split('.')
+    requester_parts = requester.split('.')
     for ip_range in ip_range_map.keys():
-        ip_range_prts = ip_range.split('.')
+        ip_range_parts = ip_range.split('.')
         match_cnt = 0
         for i in range(3):
-            if requester_prts[i] == ip_range_prts[i]:
+            if requester_parts[i] == ip_range_parts[i]:
                 match_cnt += 1
         if match_cnt:
             potential_ranges[match_cnt].append(ip_range)


### PR DESCRIPTION
  + Reduce memory foot print. Rather than building a map of all IP addresses
    use the ranges. When a request is received without region hint find
    ranges with longest possible prefix length then verify that the requester
    IP is one of the potential ranges.