### PR TITLE
Add new regions to example config file

### DIFF
--- a/ec2utils/ec2utils.conf.example
+++ b/ec2utils/ec2utils.conf.example
@@ -164,3 +164,43 @@ user = ec2-user
 # Allow a region to overwrite the account key
 # ssk_key_name =
 # ssh_private_key =
+
+[region-ca-central-1]
+ami = ami-a954d1cd
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-eu-west-2]
+ami = ami-403e2524
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-eu-west-3]
+ami = ami-8ee056f3
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-ap-south-1]
+ami = ami-531a4c3c
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-cn-northwest-1]
+ami = ami-23978241
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =


### PR DESCRIPTION
This adds the new regions

- ca-central-1
- eu-west-2
- eu-west-3
- ap-south-1

@rjschwei should we add aki_i386, aki_x86_64 = aki-880531cd and g2_aki_x86_64 as well?