### PR TITLE
- susePublicCloudInfoClient

### DIFF
--- a/susePublicCloudInfoClient/bin/pint
+++ b/susePublicCloudInfoClient/bin/pint
@@ -93,17 +93,20 @@ region = 'all'
 if command_args['--region']:
     region = command_args['--region']
 
-if command_args['images']:
-    print ifsrequest.get_image_data(
-        framework,
-        image_state,
-        output_format,
-        region,
-        command_args['--filter'])
-else:
-    print ifsrequest.get_server_data(
-        framework,
-        server_type,
-        output_format,
-        region,
-        command_args['--filter'])
+try:
+    if command_args['images']:
+        print ifsrequest.get_image_data(
+            framework,
+            image_state,
+            output_format,
+            region,
+            command_args['--filter'])
+    else:
+        print ifsrequest.get_server_data(
+            framework,
+            server_type,
+            output_format,
+            region,
+            command_args['--filter'])
+except Exception:
+    sys.exit(1)

--- a/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/infoserverrequests.py
+++ b/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/infoserverrequests.py
@@ -277,7 +277,7 @@ def __warn(str, out=sys.stdout):
 
 def __error(str, out=sys.stderr):
     out.write("Error: %s" % str)
-    sys.exit(1)
+    raise LookupError(str)
 
 
 def __process(url, info_type, command_arg_filter, result_format):

--- a/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/version.py
+++ b/susePublicCloudInfoClient/lib/susepubliccloudinfoclient/version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2015 SUSE Linux GmbH.  All rights reserved.
+# Copyright (c) 2018 SUSE Linux GmbH.  All rights reserved.
 #
 # This file is part of susePublicCloudInfoClient
 #
@@ -18,4 +18,4 @@
 # along with susePublicCloudInfoClient. If not, see
 # <http://www.gnu.org/licenses/>.
 #
-VERSION = '0.4.0'
+VERSION = '0.4.1'

--- a/susePublicCloudInfoClient/python-susepubliccloudinfo.spec
+++ b/susePublicCloudInfoClient/python-susepubliccloudinfo.spec
@@ -18,7 +18,7 @@
 
 %define upstream_name susepubliccloudinfo
 Name:           python-susepubliccloudinfo
-Version:        0.4.0
+Version:        0.4.1
 Release:        1
 Summary:        Query SUSE Public Cloud Info Service
 License:        GPL-3.0+


### PR DESCRIPTION
  + Do not use sys.exit in library to allow use outside of command line
    interface