### PR TITLE
Fix _detach_volume() call with wrong parameters

### DIFF
--- a/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
+++ b/ec2utils/ec2uploadimg/lib/ec2utils/ec2uploadimg.py
@@ -270,7 +270,7 @@ class EC2ImageUploader(EC2Utils):
                 )
         if self.created_volumes:
             for volume in self.created_volumes:
-                self._detach_volume(volume, True)
+                self._detach_volume(volume)
                 self._remove_volume(volume)
 
         self.created_volumes = []


### PR DESCRIPTION
Run ec2uploadimg leads into following exception:
"_detach_volume() takes 2 positional arguments but 3 were given"

The method signature changed with https://github.com/SUSE/Enceladus/commit/a1af80e8f9306bfa7f13c77fa7b2b80f9e0f8310#diff-4e140cc0dbecb24f9927a6ce15557b99L434 