### PR TITLE
Add repository metadata signature checker

### DIFF
--- a/monitor/README.md
+++ b/monitor/README.md
@@ -23,3 +23,9 @@ table for the process with the given name.
 
 The script monitors that the given directory is/remains empty or does not
 exist
+
+# check_repo_signatures
+
+The script monitors that repositories in the given directory have valid
+metadata GPG signatures (i.e., that `repomd.xml.asc` and `repomd.xml.key` match
+`repomd.xml`).

--- a/monitor/check_repo_signatures
+++ b/monitor/check_repo_signatures
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+
+require 'shellwords'
+require 'logger'
+require 'optparse'
+
+class RepoSignatureChecker
+  def initialize
+    @repo_dir = '/srv/www/htdocs/repo'
+    @keyring_path = '/tmp/repo-check-keyring.gpg'
+
+    parse_options
+    @logger = Logger.new(@opt_nagios ? IO::NULL : STDOUT)
+  end
+
+  def parse_options
+    OptionParser.new do |opts|
+      opts.banner = "Verifies repository metadata GPG signatures.\nUsage: #{File.basename($0)} [options]"
+
+      opts.on("-n", "--nagios", "Terse output for Nagios") { @opt_nagios = true }
+      opts.on("-d", "--dir [REPO_DIR]", "Path to repo directory") { |param| @repo_dir = param }
+    end.parse!
+  end
+
+  def check_repo(dir)
+    cmd = "gpg --no-default-keyring --keyring #{@keyring_path} --import #{dir}/repomd.xml.key 2>&1"
+    out = `#{cmd}`
+
+    if $?.exitstatus != 0
+      @logger.warn cmd
+      @logger.warn out
+      return false
+    end
+
+    cmd = "gpg --no-default-keyring --keyring #{@keyring_path} --verify #{dir}/repomd.xml.asc #{dir}/repomd.xml 2>&1"
+    out = `#{cmd}`
+
+    if $?.exitstatus != 0
+      @logger.warn cmd
+      @logger.warn out
+      return false
+    end
+
+    true
+  end
+
+  def run
+    `rm -rf #{@keyring_path}`
+    repodata_dirs = `find #{@repo_dir} -type d -name repodata`
+    if repodata_dirs.empty?
+      puts "No repositories found in #{@repo_dir}"
+      exit 2
+    end
+
+    valid_repos = 0
+    invalid_repos = 0
+
+    repodata_dirs.each_line do |line|
+      dir = Shellwords.escape(line.strip)
+      result = check_repo(dir)
+      result ? valid_repos += 1 : invalid_repos += 1
+    end
+
+    puts "Valid repos=#{valid_repos}, invalid repos=#{invalid_repos}"
+    if invalid_repos > 0
+      exit 2
+    else
+      exit 0
+    end
+  end
+end
+
+RepoSignatureChecker.new().run


### PR DESCRIPTION
Verifies that mirrored repositories have correct metadata signatures, suitable for use in monitoring.